### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * Backup
     * [borg](https://github.com/borgbackup/borg) - A deduplicating archiver with compression and encryption.
+* Infrastructure
+    * [cdktf](https://pypi.org/project/cdktf/) - A framework to define Terraform infrastructure using familiar programming languages with high-level constructs and provider integration.
 
 ## Distributed Computing
 


### PR DESCRIPTION
This adds CDK for Terraform (cdktf). CDK for Terraform lets you define Terraform infrastructure using familiar programming languages while giving you high-level constructs, modularity, and tight integration with Terraform’s provider ecosystem. It makes infrastructure code more testable and reusable.

## What is this Python project?
cdktf (Cloud Development Kit for Terraform) is a framework for defining cloud infrastructure using Terraform providers and modules. It allows users to define infrastructure resources using higher-level programming languages

Describe Features 

Writing Terraform configurations using Python instead of HCL (Terraform’s native language).
Reusable, modular constructs for building and managing infrastructure.
Full interoperability with the Terraform ecosystem—providers, modules, and state management.
Strong typing and IDE support for better development experience.
Easier automation and integration with existing Python-based DevOps workflows.

## What's the difference between this Python project and similar ones?

Terraform (HCL): cdktf uses Python (and other languages) instead of HCL, enabling loops, conditionals, and abstractions native to programming languages.
Pulumi: Both let you define infrastructure in code, but cdktf relies on Terraform’s vast provider ecosystem, whereas Pulumi uses its own engine.
Ansible or pyinfra: Those focus on configuration and orchestration after infrastructure exists; cdktf focuses on provisioning the infrastructure itself.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
